### PR TITLE
Locked tags

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -126,7 +126,7 @@ private
       has_embedded_notes
     ]
     permitted_params += %i[is_rating_locked is_note_locked] if CurrentUser.is_builder?
-    permitted_params += %i[is_status_locked] if CurrentUser.is_admin?
+    permitted_params += %i[is_status_locked locked_tags] if CurrentUser.is_admin?
 
     params.require(:post).permit(permitted_params)
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -693,11 +693,16 @@ class Post < ApplicationRecord
     end
 
     def normalize_tags
+      if !locked_tags.nil? && locked_tags.strip.blank?
+        update_attribute(:locked_tags, nil)
+      end
       normalized_tags = Tag.scan_tags(tag_string)
       normalized_tags = apply_casesensitive_metatags(normalized_tags)
       normalized_tags = normalized_tags.map {|tag| tag.downcase}
       normalized_tags = filter_metatags(normalized_tags)
       normalized_tags = remove_negated_tags(normalized_tags)
+      normalized_tags = apply_locked_tags(normalized_tags, :remove)
+      normalized_tags = apply_locked_tags(normalized_tags, :add)
       normalized_tags = TagAlias.to_aliased(normalized_tags)
       normalized_tags = %w(tagme) if normalized_tags.empty?
       normalized_tags = add_automatic_tags(normalized_tags)
@@ -705,6 +710,7 @@ class Post < ApplicationRecord
       normalized_tags = Tag.convert_cosplay_tags(normalized_tags)
       normalized_tags = normalized_tags + Tag.create_for_list(TagImplication.automatic_tags_for(normalized_tags))
       normalized_tags = TagImplication.with_descendants(normalized_tags)
+      normalized_tags = apply_locked_tags(normalized_tags, :remove) # Prevent adding locked tags through implications or aliases.
       normalized_tags = normalized_tags.compact.uniq.sort
       normalized_tags = Tag.create_for_list(normalized_tags)
       set_tag_string(normalized_tags.join(" "))
@@ -717,6 +723,21 @@ class Post < ApplicationRecord
       end
       tags - invalid_tags
     end
+
+    def apply_locked_tags(tags, phase)
+      return tags if locked_tags.nil?
+      @locked_tags ||= Tag.scan_tags(locked_tags.downcase)
+      to_remove, to_add = @locked_tags.partition {|x| x =~ /\A-/i}
+      to_remove = to_remove.map {|x| x[1..-1]}
+      @locked_to_remove ||= TagAlias.to_aliased(to_remove)
+      @locked_to_add ||= TagAlias.to_aliased(to_add)
+      if phase == :add
+        return tags + to_add
+      else
+        return tags - to_remove
+      end
+    end
+
 
     def remove_negated_tags(tags)
       @negated_tags, tags = tags.partition {|x| x =~ /\A-/i}
@@ -1929,6 +1950,9 @@ class Post < ApplicationRecord
   def reload(options = nil)
     super
     reset_tag_array_cache
+    @locked_tags = nil
+    @locked_to_add = nil
+    @locked_to_remove = nil
     @pools = nil
     @favorite_groups = nil
     @tag_categories = nil

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -92,6 +92,11 @@
       <%= f.text_area :tag_string, :size => "60x5", :spellcheck => false, :"data-autocomplete" => "tag-edit", :"data-shortcut" => "e", :value => post.presenter.split_tag_list_text + " " %>
     </div>
     <%= render "related_tags/buttons" %>
+
+    <div>
+      <%= f.label :locked_tags, "Locked Tags" %>
+      <%= f.text_area :locked_tags, :size => "60x2", :spellcheck => false, :"data-autocomplete" => "tag-edit", :"data-shortcut" => "e", :value => (post.locked_tags || "") %>
+    </div>
   </div>
   
   <div class="input">

--- a/db/migrate/20190202155518_add_locked_tags.rb
+++ b/db/migrate/20190202155518_add_locked_tags.rb
@@ -1,0 +1,6 @@
+class AddLockedTags < ActiveRecord::Migration[5.2]
+  def change
+    execute "set statement_timeout = 0"
+    add_column :posts, :locked_tags, :text, :null => true
+  end
+end

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -638,6 +638,66 @@ class PostTest < ActiveSupport::TestCase
         end
       end
 
+      context "with locked tags" do
+        context "without aliases or implications" do
+          setup do
+            @post = FactoryBot.create(:post, locked_tags: "abc -what bcd -def", tag_string: "test_tag def")
+            @tags = @post.tag_array
+          end
+
+          should "add missing tags" do
+            assert(@tags.include?("abc"))
+            assert(@tags.include?("bcd"))
+            assert(@tags.include?("test_tag"))
+          end
+
+          should "remove included tags" do
+            assert(!@tags.include?("def"))
+            assert(!@tags.include?("what"))
+          end
+        end
+
+        context 'with aliases' do
+          setup do
+            FactoryBot.create(:tag_alias, :antecedent_name => "abc", :consequent_name => "xyz")
+            FactoryBot.create(:tag_alias, :antecedent_name => "def", :consequent_name => "what")
+            @post = FactoryBot.create(:post, locked_tags: "abc -what bcd -def", tag_string: "test_tag def")
+            @tags = @post.tag_array
+          end
+
+          should "add missing tags" do
+            assert(@tags.include?("xyz"))
+            assert(!@tags.include?("abc"))
+            assert(@tags.include?("bcd"))
+            assert(@tags.include?("test_tag"))
+          end
+
+          should "remove included tags" do
+            assert(!@tags.include?("def"))
+            assert(!@tags.include?("what"))
+          end
+        end
+
+        context 'with implications' do
+          setup do
+            FactoryBot.create(:tag_implication, :antecedent_name => "abc", :consequent_name => "what")
+            @post = FactoryBot.create(:post, locked_tags: "abc -what bcd -def", tag_string: "test_tag def")
+            @tags = @post.tag_array
+          end
+
+          should "add missing tags" do
+            assert(@tags.include?("abc"))
+            assert(@tags.include?("bcd"))
+            assert(@tags.include?("test_tag"))
+          end
+
+          should "remove included tags" do
+            assert(!@tags.include?("def"))
+            assert(!@tags.include?("what"))
+          end
+        end
+      end
+
       context "tagged with a valid tag" do
         subject { @post }
 


### PR DESCRIPTION
Add the ability for admins to lock tags using tag scripts. This overrides implications to help prevent abuse.